### PR TITLE
Use iculess libxml2 and qt6-base

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -89,9 +89,19 @@ jobs:
 
     - name: Install debloated llvm-libs
       run: |
-        LLVM="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/llvm-libs-nano-x86_64.pkg.tar.zst"
-        wget "$LLVM" -O ./llvm-libs.pkg.tar.zst
+        LLVM_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/llvm-libs-mini-x86_64.pkg.tar.zst"
+        wget "$LLVM_URL" -O ./llvm-libs.pkg.tar.zst
         pacman -U --noconfirm ./llvm-libs.pkg.tar.zst
+        rm -f ./llvm-libs.pkg.tar.zst
+
+    - name: Install iculess libxml2 and qt6-core
+      run: |
+        QT6_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/qt6-base-iculess-x86_64.pkg.tar.zst"
+        LIBXML_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/libxml2-iculess-x86_64.pkg.tar.zst"
+        wget "$QT6_URL" -O ./qt6-base-iculess.pkg.tar.zst
+        wget "$LIBXML_URL" -O ./libxml2-iculess.pkg.tar.zst
+        pacman -U --noconfirm ./qt6-base-iculess.pkg.tar.zst ./libxml2-iculess.pkg.tar.zst
+        rm -f ./qt6-base-iculess.pkg.tar.zst ./libxml2-iculess.pkg.tar.zst
 
     - name: Compile Citron
       run: |

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -89,7 +89,7 @@ jobs:
 
     - name: Install debloated llvm-libs
       run: |
-        LLVM_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/llvm-libs-mini-x86_64.pkg.tar.zst"
+        LLVM_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/llvm-libs-nano-x86_64.pkg.tar.zst"
         wget "$LLVM_URL" -O ./llvm-libs.pkg.tar.zst
         pacman -U --noconfirm ./llvm-libs.pkg.tar.zst
         rm -f ./llvm-libs.pkg.tar.zst

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -42,7 +42,6 @@ jobs:
           nasm \
           qt6-tools \
           qt6-base \
-          qt6-webengine \
           qt6-multimedia \
           qt6-wayland \
           mbedtls2 \

--- a/citron-appimage.sh
+++ b/citron-appimage.sh
@@ -31,6 +31,7 @@ fi
 
 # This library is massive and makes the AppImage +220 Mib
 # Seems to have very few  uses so we will build without it
+sed -i "s/'qt6-webengine'//" ./PKGBUILD
 sed -i 's/-DCITRON_USE_QT_WEB_ENGINE=ON/-DCITRON_USE_QT_WEB_ENGINE=OFF/' ./PKGBUILD
 
 if ! grep -q -- '-O3' ./PKGBUILD; then


### PR DESCRIPTION
Shrinks the AppImage by 12 MiB. 

@lucasmz1 Can you test with your nvidia GPU to let me know everything is alright? 

[Artifact link](https://github.com/Samueru-sama/Citron-AppImage-test/releases/tag/0.4)