### PR TITLE
bump dwarfs blocksize now that uruntime got much better

### DIFF
--- a/citron-appimage.sh
+++ b/citron-appimage.sh
@@ -146,7 +146,7 @@ echo "Generating AppImage..."
 ./uruntime --appimage-mkdwarfs -f \
 	--set-owner 0 --set-group 0 \
 	--no-history --no-create-timestamp \
-	--compression zstd:level=22 -S24 -B32 \
+	--compression zstd:level=22 -S26 -B32 \
 	--header uruntime \
 	-i ./AppDir -o Citron-"$VERSION"-anylinux-"$ARCH".AppImage
 


### PR DESCRIPTION
Now the uruntime sets [DWARFS_READAHEAD=16M](https://github.com/VHSgunzo/uruntime/issues/7#issuecomment-2758967029) the launch times improved quite significantly, they were better than squashfs already and now it is insane 👀

![image](https://github.com/user-attachments/assets/fad654aa-df1c-4b3a-a3be-b3fcb4bf8f6b)

These changes make the appimage 6% smaller **and faster**  wrt to **citron-old** which is not the same Citron, it is the older version that uncompressed is slightly bigger than the current citron in the test, meaning the actual improvement is bigger. 

And setting `DWARFS_READAHEAD=32M` makes it even faster but the current defaults are good enough