### PR TITLE
add `opus-mini`

### DIFF
--- a/citron.dwfsprof
+++ b/citron.dwfsprof
@@ -49,7 +49,7 @@ shared/lib/libcairo.so.2.11804.4
 shared/lib/libgobject-2.0.so.0.8400.1
 shared/lib/libglib-2.0.so.0.8400.1
 shared/lib/libsnappy.so.1.2.2
-shared/lib/libaom.so.3.12.0
+shared/lib/libaom.so.3.12.1
 shared/lib/libgsm.so.1.0.22
 shared/lib/libjxl.so.0.11.1
 shared/lib/libjxl_threads.so.0.11.1
@@ -128,7 +128,7 @@ shared/lib/libkrb5support.so.0.1
 shared/lib/libkeyutils.so.1.10
 shared/lib/libresolv.so.2
 shared/lib/libproxy/libpxbackend-1.0.so
-shared/lib/libcap.so.2.75
+shared/lib/libcap.so.2.76
 shared/lib/libgio-2.0.so.0.8400.1
 shared/lib/libgdk_pixbuf-2.0.so.0.4200.12
 shared/lib/libpangocairo-1.0.so.0.5600.3

--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -14,6 +14,8 @@ LLVM_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/
 FFMPEG_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/ffmpeg-mini-$PKG_TYPE"
 QT6_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/qt6-base-iculess-$PKG_TYPE"
 LIBXML_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/libxml2-iculess-$PKG_TYPE"
+OPUS_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/opus-nano-$PKG_TYPE"
+MESA_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/mesa-mini-$PKG_TYPE"
 
 echo "Installing build dependencies..."
 echo "---------------------------------------------------------------"
@@ -94,18 +96,12 @@ echo "---------------------------------------------------------------"
 wget --retry-connrefused --tries=30 "$LLVM_URL" -O ./llvm-libs.pkg.tar.zst
 wget --retry-connrefused --tries=30 "$QT6_URL" -O ./qt6-base-iculess.pkg.tar.zst
 wget --retry-connrefused --tries=30 "$LIBXML_URL" -O ./libxml2-iculess.pkg.tar.zst
-wget --retry-connrefused --tries=30 "$FFMPEG_URL" -O ./ffmpeg-mini-x86_64.pkg.tar.zst
+wget --retry-connrefused --tries=30 "$FFMPEG_URL" -O ./ffmpeg-mini.pkg.tar.zst
+wget --retry-connrefused --tries=30 "$OPUS_URL" -O ./opus-nano.pkg.tar.zst
+wget --retry-connrefused --tries=30 "$MESA_URL" -O ./mesa-mini.pkg.tar.zst
 
-pacman -U --noconfirm \
-	./qt6-base-iculess.pkg.tar.zst \
-	./libxml2-iculess.pkg.tar.zst \
-	./ffmpeg-mini-x86_64.pkg.tar.zst \
-	./llvm-libs.pkg.tar.zst
-
-rm -f ./qt6-base-iculess.pkg.tar.zst \
-	./libxml2-iculess.pkg.tar.zst \
-	./ffmpeg-mini-x86_64.pkg.tar.zst \
-	./llvm-libs.pkg.tar.zst
+pacman -U --noconfirm ./*.pkg.tar.zst
+rm -f ./*.pkg.tar.zst
 
 echo "All done!"
 echo "---------------------------------------------------------------"

--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -98,7 +98,6 @@ wget --retry-connrefused --tries=30 "$QT6_URL" -O ./qt6-base-iculess.pkg.tar.zst
 wget --retry-connrefused --tries=30 "$LIBXML_URL" -O ./libxml2-iculess.pkg.tar.zst
 wget --retry-connrefused --tries=30 "$FFMPEG_URL" -O ./ffmpeg-mini.pkg.tar.zst
 wget --retry-connrefused --tries=30 "$OPUS_URL" -O ./opus-nano.pkg.tar.zst
-wget --retry-connrefused --tries=30 "$MESA_URL" -O ./mesa-mini.pkg.tar.zst
 
 pacman -U --noconfirm ./*.pkg.tar.zst
 rm -f ./*.pkg.tar.zst


### PR DESCRIPTION
Originally was goig to include a smaller version of mesa as well, but noticed a regression on totk opengl caused by building mesa with `-Os` 👀

