### PR TITLE
remove mysterious sse2neon library dependency

### DIFF
--- a/citron-appimage.sh
+++ b/citron-appimage.sh
@@ -51,7 +51,7 @@ fi
 	#TODO: Remove once a new stable release is made
 	find src -type f -name '*.cpp' -exec sed -i 's/boost::asio::io_service/boost::asio::io_context/g' {} \;
 
-	# remove mysteriours sse2neon library dependency
+	# remove mysterious sse2neon library dependency
 	sed -i '/sse2neon/d' ./src/video_core/CMakeLists.txt
 
 	mkdir build

--- a/citron-appimage.sh
+++ b/citron-appimage.sh
@@ -51,6 +51,9 @@ fi
 	#TODO: Remove once a new stable release is made
 	find src -type f -name '*.cpp' -exec sed -i 's/boost::asio::io_service/boost::asio::io_context/g' {} \;
 
+	# remove mysteriours sse2neon library dependency
+	sed -i '/sse2neon/d' ./src/video_core/CMakeLists.txt
+
 	mkdir build
 	cd build
 	cmake .. -GNinja \

--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -89,13 +89,6 @@ if [ "$(uname -m)" = 'x86_64' ]; then
 	pacman -Syu --noconfirm vulkan-intel haskell-gnutls gcc13 svt-av1
 else
 	pacman -Syu --noconfirm vulkan-freedreno vulkan-panfrost
-	
-	# make sse2neon needed for aarch64
-	git clone https://github.com/DLTcollab/sse2neon.git ./sse2neon && (
-		cd ./sse2neon
-		make
-		cp -v ./sse2neon.h /usr/include
-	)
 fi
 
 

--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -89,7 +89,15 @@ if [ "$(uname -m)" = 'x86_64' ]; then
 	pacman -Syu --noconfirm vulkan-intel haskell-gnutls gcc13 svt-av1
 else
 	pacman -Syu --noconfirm vulkan-freedreno vulkan-panfrost
+	
+	# make sse2neon needed for aarch64
+	git clone https://github.com/DLTcollab/sse2neon.git ./sse2neon && (
+		cd ./sse2neon
+		make
+		cp -v ./sse2neon.h /usr/include
+	)
 fi
+
 
 # fix build failing with new version of boost
 # /usr/include/boost/async_pipe.hpp is gone on boos-t1.88. not sure if intended or a bug

--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -91,7 +91,6 @@ else
 	pacman -Syu --noconfirm vulkan-freedreno vulkan-panfrost
 fi
 
-
 # fix build failing with new version of boost
 # /usr/include/boost/async_pipe.hpp is gone on boos-t1.88. not sure if intended or a bug
 if [ "$(uname -m)" = 'x86_64' ]; then


### PR DESCRIPTION
Upstream [revert](https://git.citron-emu.org/citron/emu/-/commit/03aab9becc2326e11ed3b0f04fea4144fd549f8a) added a dependency to some sse2neon shared library.

That library just doesn't exist! even asked [upstream directly](https://github.com/DLTcollab/sse2neon/issues/668). There is only one google result without source on how such lib was made.

* What's more weird is that [archlinux arm has a yuzu package](https://archlinuxarm.org/packages/aarch64/yuzu), **unfortunately checking the source files results in an error**, meaning I don't know still how they dealt with this issue. 

* @sounddrill31 also found [these rpms](https://www.rpmfind.net/linux/rpm2html/search.php?query=sse2neon&submit=Search+) of sse2neon but they don't contain shared libs.

It seems the only way to find out about this lib is by finding out the yuzu dev that added it originally lol
